### PR TITLE
Fixed the issue of matching failure in other language environments.

### DIFF
--- a/src/MoveItem__GameManager_LateUpdate_Patch.cs
+++ b/src/MoveItem__GameManager_LateUpdate_Patch.cs
@@ -8,7 +8,6 @@ using HarmonyLib;
 
 namespace LoadTravois
 {
-
     [HarmonyPatch(typeof(GameManager), "LateUpdate")]
     public static class MoveItem__GameManager_LateUpdate_Patch
     {
@@ -21,25 +20,26 @@ namespace LoadTravois
 
         public static void Postfix(GameManager __instance)
         {
-             if (Plugin.HotKey.Value.IsPressed() && !GraphicsManager.Instance.HasPopup)
+            if (Plugin.HotKey.Value.IsPressed() && !GraphicsManager.Instance.HasPopup)
             {
                 CardData currentEnvironment = GameManager.Instance.CurrentEnvironment;
 
                 //Find a Travois
-                InGameCardBase travois = __instance.ItemCards.SingleOrDefault(x => x.CardName() == "Travois" && x.Environment == currentEnvironment);
+                InGameCardBase travois = __instance.ItemCards.SingleOrDefault(x =>
+                    x.CardModel.CardName.DefaultText == "Travois" && x.Environment == currentEnvironment);
                 
                 if (travois == null)
                 {
                     return;
                 }
 
-                List<InGameCardBase> environmentCards = __instance.ItemCards
+                var environmentCards = __instance.ItemCards
                     .Where(x => x.Environment == currentEnvironment).ToList();
 
                 var containers = Plugin.CardMoveList
-                    .Join(environmentCards , filter => filter.Value,
-                        card => card.CardName(), (containerFilter, card) => new { containerFilter, card})
-                    .Where(x => x.card.CurrentContainer?.CardName() != "Travois" )
+                    .Join(environmentCards, filter => filter.Value,
+                        card => card.CardModel.CardName.DefaultText, (containerFilter, card) => new {containerFilter, card})
+                    .Where(x => x.card.CurrentContainer?.CardModel.CardName.DefaultText != "Travois")
                     .OrderBy(x => x.containerFilter.Key)
                     .Select(x => x.card)
                     .ToList();
@@ -49,8 +49,6 @@ namespace LoadTravois
                     DropInInventoryInfo.Invoke(travois, new object[] { container });
                 }
             }
-
         }
-
     }
 }


### PR DESCRIPTION
If the game is using another language, the CardName() method will return LocalizedText, resulting in "travois" not being found.